### PR TITLE
Corrección /tmp/new.sh de sólo lectura

### DIFF
--- a/customize/customize-minino.sh
+++ b/customize/customize-minino.sh
@@ -16,7 +16,7 @@ readonly DEBUG='n'
 # pruebas sin que el cambio de "release" afecte a los usuarios que ya tenga
 # autoupdate en Minino
 
-REPO_GITHUB=jasvazquez/minino-TDE
+REPO_GITHUB=aosucas499/minino-TDE
 
 # -----------------------------------------------------------------------------
 # Definición de las funciones utilizadas en el script

--- a/customize/customize-minino.sh
+++ b/customize/customize-minino.sh
@@ -12,6 +12,12 @@
 
 readonly DEBUG='n'
 
+# NOTA cambiar de aosucas499/minino-TDE a jasvazquez/minino-TDE para poder hacer
+# pruebas sin que el cambio de "release" afecte a los usuarios que ya tenga
+# autoupdate en Minino
+
+REPO_GITHUB=jasvazquez/minino-TDE
+
 # -----------------------------------------------------------------------------
 # Definición de las funciones utilizadas en el script
 # -----------------------------------------------------------------------------
@@ -54,7 +60,7 @@ function controlPresencia {
 	# Descargamos y copiamos el ejecutable de firefox en modo kiosk que se ejecutará en cada inicio  
 	# con un retardo para que le dé tiempo al script ntp de corregir la hora
 	#---
-	wget https://raw.githubusercontent.com/aosucas499/minino-TDE/main/tools/Firefox-latest-sleep30
+	wget "https://raw.githubusercontent.com/$REPO_GITHUB/main/tools/Firefox-latest-sleep30"
     	sudo mv Firefox-latest-sleep30 /etc/xdg/autostart/Firefox-latest-sleep30.desktop
 
 	## Informa al usuario de varios aspectos a tener en cuenta
@@ -171,7 +177,7 @@ function qshutdown {
 	# con la hora dada por el usuario
 	#
 	mkdir ~/.qshutdown/
-	wget https://raw.githubusercontent.com/aosucas499/minino-TDE/main/tools/qshutdown.conf -O /home/$USER/.qshutdown/qshutdown.conf
+	wget "https://raw.githubusercontent.com/$REPO_GITHUB/main/tools/qshutdown.conf" -O /home/$USER/.qshutdown/qshutdown.conf
 	sed -i -e "s/14:01/$shutdowntime/g" ~/.qshutdown/qshutdown.conf
 	sudo cp /usr/share/applications/qshutdown.desktop /etc/xdg/autostart/	
 }
@@ -624,7 +630,7 @@ function getOpcionesDescartadas {
 
 function getLatestRelease() {
 	
-    version=$(wget --quiet -O- -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/aosucas499/minino-TDE/releases | grep '"tag_name":' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/')
+    version=$(wget --quiet -O- -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/$REPO_GITHUB/releases" | grep '"tag_name":' | head -n 1 | sed -E 's/.*"([^"]+)".*/\1/')
     
     # NOTA  a pesar de la polémica main/master, a día de hoy Github 
     #       redirecciona sin problemas usemos la que usemos 
@@ -639,7 +645,7 @@ function getLatestRelease() {
 descargarCustomizeMinino(){
     
     versionActual=$(getLatestRelease)
-    wget -q "https://raw.githubusercontent.com/aosucas499/minino-TDE/$versionActual/customize/customize-minino.sh" -O /tmp/new2.sh
+    wget -q "https://raw.githubusercontent.com/$REPO_GITHUB/$versionActual/customize/customize-minino.sh" -O /tmp/new2.sh
 }
 
 

--- a/customize/customize-minino.sh
+++ b/customize/customize-minino.sh
@@ -705,7 +705,7 @@ function isConnectionAvailable {
 # Evitamos colisiones con otros scripts
 # ---
 
-rm -f /tmp/new.sh
+rm -f /tmp/new2.sh
 
 # Comprobamos si hay internet
 # ---

--- a/update-minino.sh
+++ b/update-minino.sh
@@ -12,7 +12,7 @@
 # pruebas sin que el cambio de "release" afecte a los usuarios que ya tenga
 # autoupdate en Minino
 
-REPO_GITHUB=aosucas499/minino-TDE
+REPO_GITHUB=jasvazquez/minino-TDE
 
 FIREFOX=https://download-installer.cdn.mozilla.net/pub/firefox/releases/83.0/linux-i686/es-ES/firefox-83.0.tar.bz2
 LANZADOR=https://raw.githubusercontent.com/aosucas499/actualiza-firefox/master/firefox-latest.desktop

--- a/update-minino.sh
+++ b/update-minino.sh
@@ -12,7 +12,7 @@
 # pruebas sin que el cambio de "release" afecte a los usuarios que ya tenga
 # autoupdate en Minino
 
-REPO_GITHUB=jasvazquez/minino-TDE
+REPO_GITHUB=aosucas499/minino-TDE
 
 FIREFOX=https://download-installer.cdn.mozilla.net/pub/firefox/releases/83.0/linux-i686/es-ES/firefox-83.0.tar.bz2
 LANZADOR=https://raw.githubusercontent.com/aosucas499/actualiza-firefox/master/firefox-latest.desktop


### PR DESCRIPTION
Tras comprobar que `update-minino` deja un fichero `/tmp/new.sh` creado con permisos de sudo, se comprueba que tras el último cambio en la nomenclatura de los ficheros había provocado que `customize-minino` (que pasó a usar new2.sh) tratase de borrar el fichero new.sh generado (al iniciar sesión) por `update-minino`